### PR TITLE
Correct numbering

### DIFF
--- a/website/pages/aoc_en.md
+++ b/website/pages/aoc_en.md
@@ -18,16 +18,18 @@ many problems have been solved at the end of the competition.
 
 The 10 best competitors will win gift cards with matching sums:
 
-0.  1500 SEK
-1.  1000 SEK
-2.  750 SEK
-3.  500 SEK
-4.  500 SEK
-5.  500 SEK
-6.  200 SEK
-7.  200 SEK
-8.  200 SEK
-9.  200 SEK
+<ol start="0">
+<li> 1500 kr </li>
+<li> 1000 kr </li>
+<li> 750 kr </li>
+<li> 500 kr </li>
+<li> 500 kr </li>
+<li> 500 kr </li>
+<li> 200 kr </li>
+<li> 200 kr </li>
+<li> 200 kr </li>
+<li> 200 kr </li>
+</ol>
 
 Winners are chosen primarily based on the amount of problems solved and
 secondly on the points awarded by Advent of Code.

--- a/website/pages/aoc_se.md
+++ b/website/pages/aoc_se.md
@@ -18,16 +18,18 @@ på hur många problem som löses innan slutet av tävlingen.
 
 De 10 bästa deltagarna kommer att vinna presentkort med motsvarande summor:
 
-0.  1500 kr
-1.  1000 kr
-2.  750 kr
-3.  500 kr
-4.  500 kr
-5.  500 kr
-6.  200 kr
-7.  200 kr
-8.  200 kr
-9.  200 kr
+<ol start="0">
+<li> 1500 kr </li>
+<li> 1000 kr </li>
+<li> 750 kr </li>
+<li> 500 kr </li>
+<li> 500 kr </li>
+<li> 500 kr </li>
+<li> 200 kr </li>
+<li> 200 kr </li>
+<li> 200 kr </li>
+<li> 200 kr </li>
+</ol>
 
 Vinnarna kommer att utses främst utifrån antal lösta problem och därefter
 utifrån poäng som utdelas av Advent of Code.


### PR DESCRIPTION
Ordered lists in HTML automatically start at 1 so it has to be explicitly corrected to 0.