### PR TITLE
Fixups to the publish script

### DIFF
--- a/publish
+++ b/publish
@@ -40,7 +40,7 @@ python freezer.py
 if [[ $? -ne 0 ]]; then
 	echo "Failed to build, have you setup the environment."
 	echo "Removing temporary branch..."
-	git checkout master
+	git checkout -
 	git branch -D gh-pages
 	exit 1
 fi
@@ -55,7 +55,7 @@ git commit -m "Publish $(date -I)" --no-gpg-sign
 git push -f --set-upstream origin gh-pages
 
 echo "Removing temporary branch..."
-git checkout master
+git checkout -
 git branch -D gh-pages
 
 echo "Done publishing"

--- a/publish
+++ b/publish
@@ -1,5 +1,18 @@
 #!/usr/bin/env bash
 
+PUBLISH=1
+while [[ $# -gt 0 ]]
+do
+    key="$1"
+    case $key in
+    -d|--dry-run)
+        PUBLISH=0
+        shift
+        shift
+        ;;
+    esac
+done
+
 errors=0
 # Ensure changes are committed
 if [[ $(git status -s) ]]; then
@@ -7,14 +20,8 @@ if [[ $(git status -s) ]]; then
 	errors=1
 fi
 
-# Make sure the person running this script has rsync
-if ! type rsync &> /dev/null; then
-    echo "Error: You have to install rsync to run this script"
-	errors=1
-fi
-
 # Ensure user is publishing from master branch
-if [[ "$(git rev-parse --abbrev-ref HEAD)" != "master" ]]; then
+if [[ "$(git rev-parse --abbrev-ref HEAD)" != "master" ]] && [[ $PUBLISH -eq 1 ]]; then
 	echo "Error: Can only publish from \"master\" branch"
 	errors=1
 fi
@@ -46,16 +53,20 @@ if [[ $? -ne 0 ]]; then
 fi
 
 echo "Moving static files..."
-rsync -a website/build/* .
-rsync -a website/other/* .
+cp -r website/build/* .
+cp -r website/other/* .
 
-echo "Sending files to remote..."
-git add --all
-git commit -m "Publish $(date -I)" --no-gpg-sign
-git push -f --set-upstream origin gh-pages
+if [[ $PUBLISH -eq 1 ]]; then
+    echo "Sending files to remote..."
+    git add --all
+    git commit -m "Publish $(date -I)" --no-gpg-sign
+    git push -f --set-upstream origin gh-pages
 
-echo "Removing temporary branch..."
-git checkout -
-git branch -D gh-pages
+    echo "Removing temporary branch..."
+    git checkout -
+    git branch -D gh-pages
 
-echo "Done publishing"
+    echo "Done publishing"
+else
+    echo "Skipping push"
+fi


### PR DESCRIPTION
- Don't go back to master branch after push.
- Remove rsync, completely unessecary dependency.
- flag for not running git push, so you can try out the version locally.

