### PR TITLE
Remove width on #important-information

### DIFF
--- a/website/static/style.css
+++ b/website/static/style.css
@@ -605,7 +605,6 @@ img.sponsor {
 }
 
 #important-information {
-    width: 100%;
     padding: 0em 1em;
 
     background-color: var(--footer-bg-color);


### PR DESCRIPTION
Currently the info box hangs to the right, which isn't really noticeable on desktop but very much so on mobile. See images below. 

With `width`:
https://user-images.githubusercontent.com/4735435/91165013-45fcc180-e6d0-11ea-92d6-c56a0a2e550e.png
https://user-images.githubusercontent.com/4735435/91165115-73496f80-e6d0-11ea-9319-9437a9a06396.png

Without `width`:
https://user-images.githubusercontent.com/4735435/91165155-82302200-e6d0-11ea-823a-521984e506c2.png
https://user-images.githubusercontent.com/4735435/91165156-82c8b880-e6d0-11ea-9b5a-915ce6058566.png

