### PR TITLE
Update aoc information regarding non-competitors (and fix prize list)

### DIFF
--- a/website/pages/aoc_en.md
+++ b/website/pages/aoc_en.md
@@ -1,8 +1,11 @@
 <div id="important-information">
     <p>
-        Due to unforseen consequences we were forced to reset the leaderboard
+        (2020-12-01) Due to unforseen consequences we were forced to reset the leaderboard
         today. If you are no longer in the leaderboard, you need to join it
-        again. Note also that only students at LiU are allowed to participate.
+        again.
+    </p>
+    <p>
+        (2020-12-04) We've also added information about non-competitors below.
     </p>
     <p>
         Excuse the mess // LiTHe kod
@@ -21,12 +24,30 @@ problem. 10 sek to COVID-19 research and 10 sek to Advent of Code itself. There
 will of course be a kickoff for Advent of Code at the meetup the first of
 December! See you there!
 
-The leaderboard below is sorted a bit different from the one at the Advent of
-Code site. This is our official sorting which prioritizes stars first and
-points second.
+In addition to our Advent of Code leaderboard, we also arrange our own
+competition. We use a sorting that's a little different to the one on Advent of
+Code's site where we primarily sort by number of stars and secondarily by the
+number of points. Only people studying at LiU are eligible to compete but you
+can press a super advanced button below to also show non-competitors. If you
+think that you should be on the competition list but aren't, please contact
+someone in the board and we'll take a look at it. (You can also contact us if
+you don't want to be on the competition list.)
 
-Prizes are dealt out according to the following after the competition has
-ended: First place 1500 sek, second place 1100 sek, third place 750 sek, 4:th to and including 6:th place 500 sek, 7:th to and including 10:th place 250 sek.
+Prizes are dealt out according to the following after the competition has ended:
+
+<ol start="0">
+<li>1500 SEK</li>
+<li>1100 SEK</li>
+<li>750 SEK </li>
+<li>500 SEK </li>
+<li>500 SEK </li>
+<li>500 SEK </li>
+<li>250 SEK </li>
+<li>250 SEK </li>
+<li>250 SEK </li>
+<li>250 SEK </li>
+</ol>
+
 
 <div id="sponsor-container">
     <img class="sponsor" src="/static/img/mindroad_logo.png" alt="Mindroad">

--- a/website/pages/aoc_se.md
+++ b/website/pages/aoc_se.md
@@ -1,8 +1,11 @@
 <div id="important-information">
     <p>
-        På grund av oförutsedda konsekvenser var vi idag tvugna att återställa
+        (2020-12-01) På grund av oförutsedda konsekvenser var vi idag tvugna att återställa
         leaderboarden. Om du inte är med i leaderboarden längre behöver du gå med
-        igen. Notera också att det endast är studerande vid LiU som får delta.
+        igen.
+    </p>
+    <p>
+        (2020-12-04) Vi har också lagt till information om icke-tävlande nedan.
     </p>
     <p>
         Ursäkta röran // LiTHe kod
@@ -21,13 +24,28 @@ gåvor, så därför kommer LiTHe kod att donera 20kr för varje löst deluppgif
 Givetvis kommer vi ha en Advent of Code-kickoff på meetupen den första december!
 Ses där!
 
-Leaderboarden nedan sorteras lite annorlunda från den som finns på Advent of
-Code-sidan. Detta är vår officiella sortering som prioriterar stjärnor först
-och poäng därefter.
+Utöver vår Advent of Code-leaderboard håller LiTHe kod i en egen tävling. Vi
+använder en lite annorlunda sortering än den på Advent of Codes hemsida där vi i
+första hand sorterar efter stjärnor och sedan poäng. Endast LiU-studerande får
+vara med och tävla om priserna men det går att trycka på en superavancerad knapp
+för att visa även icke-tävlande. Om du tycker att du visst studerar på LiU men
+inte är med på listan får du gärna kontakta någon i styrelsen så löser vi det.
+(Du kan också kontakta oss om du inte vill vara med i tävlingen.)
 
-Priser delas ut enligt följande efter tävlingens slut: Första plats 1500kr,
-andra plats 1100kr, tredje plats 750kr, 4:e till och med 6:e plats 500kr, 7:e
-till och med 10:e plats 250kr.
+Priserna delas ut enligt följande efter tävlingens slut.
+
+<ol start="0">
+<li>1500 SEK</li>
+<li>1100 SEK</li>
+<li>750 SEK </li>
+<li>500 SEK </li>
+<li>500 SEK </li>
+<li>500 SEK </li>
+<li>250 SEK </li>
+<li>250 SEK </li>
+<li>250 SEK </li>
+<li>250 SEK </li>
+</ol>
 
 <div id="sponsor-container">
     <img class="sponsor" src="/static/img/mindroad_logo.png" alt="Mindroad">


### PR DESCRIPTION
Texten hänvisar till en i nuläget icke-existerande knapp (#40) som gärna är funktionell innan det här går igenom.