### PR TITLE
fix header zoom issue

### DIFF
--- a/website/static/style.css
+++ b/website/static/style.css
@@ -351,7 +351,7 @@ input[type="checkbox"]:checked+#body #dark-theme {
 
 header {
     max-height: 10em;
-    height: 15vh;
+    height: 25vh;
     flex: 0 0 auto;
     margin-bottom: 2em;
 }


### PR DESCRIPTION
There is still a small issue with the image moving a bit up and down sometimes but it's much better than before.

Closes #75.

![Peek 2021-10-19 15-54](https://user-images.githubusercontent.com/4735435/137924806-8e2d39bb-372e-4a30-8476-43d897ac6364.gif)

Game jam banner from #89:

![image](https://user-images.githubusercontent.com/4735435/137925539-8c7f7ba1-f0eb-486a-adc7-5e89105d1559.png)

![image](https://user-images.githubusercontent.com/4735435/137925652-51d5dd27-4598-4439-a061-97525db39525.png)
