### PR TITLE
Add last updated to pages

### DIFF
--- a/website/__init__.py
+++ b/website/__init__.py
@@ -1,4 +1,7 @@
 # -*- coding: utf-8 -*-
+import datetime
+import subprocess
+
 import markdown2
 
 from flask import (
@@ -28,6 +31,16 @@ navigation = [
 # These functions make it easy to render files into pages or
 # redirecting to other pages.
 
+def last_updated(path):
+    """Return the author date of the latest commit that touched a path."""
+    # %at is author time as unix timestamp
+    git_cmd = "git log --format=%at -- {}".format(path).split()
+    stdout = subprocess.run(git_cmd, capture_output=True).stdout
+    ts = stdout.split(b"\n")[0]
+    dt = datetime.datetime.fromtimestamp(int(ts)).date().isoformat()
+    return dt
+
+
 def render_page(path, url, swedish, injection=""):
     """Render a Markdown file into a page on the website.
 
@@ -40,6 +53,7 @@ def render_page(path, url, swedish, injection=""):
     return render_template("page.html",
             html=markdown2.markdown_path(path),
             injection=injection,
+            last_updated=last_updated(path),
             url=url,
             navigation=navigation,
             selected=nav_index,

--- a/website/templates/page.html
+++ b/website/templates/page.html
@@ -2,4 +2,9 @@
 {% block content %}
 {{ html | safe }}
 {{ injection | safe }}
+<p>
+<small>
+    {{ "Senast uppdaterad" if swedish else "Last updated" }}: {{ last_updated }}
+</small>
+</p>
 {% endblock %}


### PR DESCRIPTION
This adds a "last updated" ("senast uppdaterad") to the bottom of all pages that use the page.html template.

Like this:
![image](https://user-images.githubusercontent.com/4735435/138523132-1a9fc7e8-9d92-4774-a2c1-9b09440243d2.png)

It makes most sense on the pages that see new information regularly (contests and game jams mostly) but it felt nice to have it everywhere.