### PR TITLE
Add LiU Game Jam header and return-to-main-page links to game jam pages 

### DIFF
--- a/website/pages/gamejam_en.md
+++ b/website/pages/gamejam_en.md
@@ -1,3 +1,8 @@
+<div id="gamejam-header">
+  <img src="/static/img/gamejam/logo.png" alt="LiU Game Jam">
+  <h1>LiU Game Jam</h1>
+</div>
+
 <img src="/static/img/gamejam/banner-fgj21.png" alt="Fall Game Jam 2021" id="gamejam-banner">
 
 # Fall Game Jam 2021

--- a/website/pages/gamejam_history_en.md
+++ b/website/pages/gamejam_history_en.md
@@ -3,6 +3,8 @@
   <h1>LiU Game Jam</h1>
 </div>
 
+[⇦ Back to LiU Game Jam's main page](/gamejam/en)
+
 # History
 
 LiU Game Jam has been been around since 2012. It started as its own group but joined forces with LiTHe kod in 2015.

--- a/website/pages/gamejam_history_en.md
+++ b/website/pages/gamejam_history_en.md
@@ -1,3 +1,8 @@
+<div id="gamejam-header">
+  <img src="/static/img/gamejam/logo.png" alt="LiU Game Jam">
+  <h1>LiU Game Jam</h1>
+</div>
+
 # History
 
 LiU Game Jam has been been around since 2012. It started as its own group but joined forces with LiTHe kod in 2015.

--- a/website/pages/gamejam_history_se.md
+++ b/website/pages/gamejam_history_se.md
@@ -1,3 +1,8 @@
+<div id="gamejam-header">
+  <img src="/static/img/gamejam/logo.png" alt="LiU Game Jam">
+  <h1>LiU Game Jam</h1>
+</div>
+
 # Historia
 
 LiU Game Jam har arrangerat events sedan 2012. Det startade som sin egna grupp men slogs samman med LiTHe kod år 2015.

--- a/website/pages/gamejam_history_se.md
+++ b/website/pages/gamejam_history_se.md
@@ -3,6 +3,8 @@
   <h1>LiU Game Jam</h1>
 </div>
 
+[⇦ Tillbaka till huvudsidan för LiU Game Jam](/gamejam/se)
+
 # Historia
 
 LiU Game Jam har arrangerat events sedan 2012. Det startade som sin egna grupp men slogs samman med LiTHe kod år 2015.

--- a/website/pages/gamejam_se.md
+++ b/website/pages/gamejam_se.md
@@ -1,3 +1,8 @@
+<div id="gamejam-header">
+  <img src="/static/img/gamejam/logo.png" alt="LiU Game Jam">
+  <h1>LiU Game Jam</h1>
+</div>
+
 <img src="/static/img/gamejam/banner-fgj21.png" alt="Fall Game Jam 2021" id="gamejam-banner">
 
 # Fall Game Jam 2021

--- a/website/pages/gamejam_tools_en.md
+++ b/website/pages/gamejam_tools_en.md
@@ -3,6 +3,8 @@
   <h1>LiU Game Jam</h1>
 </div>
 
+[⇦ Back to LiU Game Jam's main page](/gamejam/en)
+
 # Jam tools
 
 These tools works great for game jams and are mostly free.

--- a/website/pages/gamejam_tools_en.md
+++ b/website/pages/gamejam_tools_en.md
@@ -1,3 +1,8 @@
+<div id="gamejam-header">
+  <img src="/static/img/gamejam/logo.png" alt="LiU Game Jam">
+  <h1>LiU Game Jam</h1>
+</div>
+
 # Jam tools
 
 These tools works great for game jams and are mostly free.

--- a/website/pages/gamejam_tools_se.md
+++ b/website/pages/gamejam_tools_se.md
@@ -1,3 +1,8 @@
+<div id="gamejam-header">
+  <img src="/static/img/gamejam/logo.png" alt="LiU Game Jam">
+  <h1>LiU Game Jam</h1>
+</div>
+
 # Bra verktyg
 
 ### Verktyg för att skapa datorspel

--- a/website/pages/gamejam_tools_se.md
+++ b/website/pages/gamejam_tools_se.md
@@ -3,6 +3,8 @@
   <h1>LiU Game Jam</h1>
 </div>
 
+[⇦ Tillbaka till huvudsidan för LiU Game Jam](/gamejam/se)
+
 # Bra verktyg
 
 ### Verktyg för att skapa datorspel

--- a/website/static/style.css
+++ b/website/static/style.css
@@ -680,6 +680,22 @@ img.sponsor {
     border-color: var(--link-color);
 }
 
+#gamejam-header img {
+    height: 2.5em;
+    width: auto;
+    margin: 0;
+    float: left;
+    left: 0px;
+}
+
+#gamejam-header h1 {
+    font-size: 2.5em;
+    bottom: 0.25em;
+    margin-bottom: -0.25em;
+    position: relative;
+    left: 10px;
+}
+
 #gamejam-logo {
     width: 15em;
     margin: auto;


### PR DESCRIPTION
Adds headers to clarify that you are on LiU Game Jam pages and that you have found the correct sites when finding them through "LiU Game Jam" google searches.

Also adds links to main game jam page from subpages to make returning from them easier.

The latter could definitely get its own pull request but the links' current placement only makes sense with the headers in place and since dependency between pull requests on GitHub doesn't seem to be a thing, combining the two commits into a single pull request was the easiest approach.