### PR TITLE
quick lödöl

### DIFF
--- a/website/__init__.py
+++ b/website/__init__.py
@@ -130,6 +130,8 @@ pages = [
     ("/microjam/", "website/pages/microjam_{}.md"),
     ("/meetings/", "website/pages/meetings_{}.md"),
     ("/git/", "website/pages/git_{}.md"),
+
+    ("/lodol/", "website/pages/lodol_{}.md"),
 ]
 
 for url, md_file in pages:

--- a/website/pages/lodol_en.md
+++ b/website/pages/lodol_en.md
@@ -1,0 +1,12 @@
+# Lödöl 2022
+
+This year we're tyring again wth the lödöl ("solder-beer"). As the name implies
+we will solder and drink beer. We're going to solder small sensors to a circuit
+board and write code that does something fun. Beer or an alternative beverage
+will be served alongside.
+
+The Lödöl is held in collaboration with MindRoad who will supply both hardware
+and know-how on site. They will also be avaiable for questions about sommarjobb
+and other opportunities.
+
+The sign-up form will be avaiable at this URL shortly, so stay tuned!

--- a/website/pages/lodol_se.md
+++ b/website/pages/lodol_se.md
@@ -1,0 +1,11 @@
+# Lödöl 2022
+
+I år gör vi då ett nytt försök med lödöl. Som namnet antyder går det ut på att
+löda och dricka öl. Vi löder små sensorer på ett kretskort och skriver sedan kod
+till det som gör något kul. Samtidigt serveras öl eller annan alternativ dryck.
+
+Lödölen hålls i samarbete med MindRoad som står för både hårdvara och kompetens
+på plats. Självfallet kommer dom finnas tillgängliga på plats för frågor om
+sommarjobb och andra möjligheter.
+
+Anmälningsformuläret kommer upp inom kort så håll utkik här!


### PR DESCRIPTION
Lödölsposters uppe men anmälningsformuläret är inte klart. Snabb sida för att inte länka till en 404 på posters. Merge innan måndag gärna, då folk kommer tillbaka till campus.